### PR TITLE
[ Hacathon Submission ] : mark.md – Documentation Extraction Tool

### DIFF
--- a/submissions/mark.md
+++ b/submissions/mark.md
@@ -27,10 +27,10 @@ Next.js, Node.js , TypeScript, JavaScript , Vercel, Appwrite , Tailwind CSS , Tw
 - [ ] Auth
 - [ ] Databases
 - [ ] Storage
-- [ ] Functions
+- [x] Functions
 - [ ] Messaging
 - [ ] Realtime
-- [ ] Sites
+- [x] Sites
 
 ## Project Repo
 
@@ -40,4 +40,10 @@ https://github.com/priyanshuthapliyal2005/mark.md
 https://markmd.appwrite.network/
 
 ## Demo Video/Photos
+
+<img width="1898" height="850" alt="image" src="https://github.com/user-attachments/assets/e6000c51-08fc-4a1c-9539-2e4466d6806d" />
+<img width="1893" height="854" alt="image" src="https://github.com/user-attachments/assets/791acde6-83c2-4d8f-93f3-28e6bdb9edb5" />
+
+https://youtu.be/Lh6dGgYS2jI
+
 


### PR DESCRIPTION
# Hackathon Submission:  mark.md

## Name
_Enter your full name_
Priyanshu Thapliyal
<!--

Aditya Oberai

-->

## GitHub handle  
_Enter your GitHub handle_
@priyanshuthapliyal2005
<!--

@adityaoberai

-->

## Are you registered on our [Hackathon Signup page](https://apwr.dev/hf2025-hackathon)?
_This is a mandatory step for all participants to be considered eligible for judging_

- [x] Yes
- [ ] No

---

## Rules and Code of Conduct  
_By submitting this PR, you agree to follow our Rules and Code of Conduct._

- [x] Yes

---

## Anything Else?  
mark.md is a web tool that extracts clean Markdown, HTML, or plain text from any website.
It solves the problem of messy copy-paste from documentation sites (like Appwrite Docs or Supabase Docs) and helps developers easily reuse or process docs for LLMs and automation tools.
Built using Next.js, TypeScript, and Appwrite, and hosted on Vercel.

Live Demo: https://markmd.appwrite.network/
GitHub Repo: https://github.com/priyanshuthapliyal2005/mark.md